### PR TITLE
Fix NullReference when transfering infusions into empty amplifiers.

### DIFF
--- a/Source/CompTargetEffect_Enchant.cs
+++ b/Source/CompTargetEffect_Enchant.cs
@@ -14,9 +14,10 @@ namespace Infused
 
             CompInfused infused = target.TryGetComp<CompInfused>();
 
-            var toTranfer = parent.GetComp<CompInfused>().Infusions.ToList();
+            var toTranfer = parent.TryGetComp<CompInfused>()?.Infusions.ToList();
             if (toTranfer.NullOrEmpty())
             {
+                // parent is an empty amplifier; transfer one random infusion from the target to this amplifier
                 List<Def> list = infused.RemoveRandom(Rand.Range(1, Settings.max));
                 Thing amplifier = ThingMaker.MakeThing(ResourceBank.Things.InfusedAmplifier);
                 infused = amplifier.TryGetComp<CompInfused>();
@@ -29,6 +30,7 @@ namespace Infused
             }
             else
             {
+                // transfer infusions from an amplifier into the target
                 foreach (Def infusion in toTranfer)
                 {
                     infused.Attach(infusion);


### PR DESCRIPTION
I ran into problems when trying to extract infusions from items to empty amplifiers - this worked before in 1.5 , but something in 1.6 seems to be different. This fixes it to work with 1.6